### PR TITLE
Update htaccess to vary on language

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -29,15 +29,18 @@ RewriteEngine On
     RewriteCond %{HTTP:Accept-Language} ^pl [NC]
     RewriteRule ^$ /pl/ [L,R=301]
 
-    RewriteCond %{HTTP:Accept-Language} ^pt-BR [NC]
+    RewriteCond %{HTTP:Accept-Language} ^pt-br [NC]
     RewriteRule ^$ /pt-br/ [L,R=301]
 
     RewriteCond %{HTTP:Accept-Language} ^ru [NC]
     RewriteRule ^$ /ru/ [L,R=301]
 
-    RewriteCond %{HTTP:Accept-Language} ^zh-CN [NC]
+    RewriteCond %{HTTP:Accept-Language} ^zh-cn [NC]
     RewriteRule ^$ /zh-chs/ [L,R=301]
 
-    RewriteCond %{HTTP:Accept-Language} ^zh-TW [NC]
+    RewriteCond %{HTTP:Accept-Language} ^zh-tw [NC]
     RewriteRule ^$ /zh-cht/ [L,R=301]
+
+    # Don't cache one language for another
+    Header always merge Vary "Accept-Language"
 </IfModule>


### PR DESCRIPTION
This should prevent cached redirects. I still don't know why #19 is happening though - seems to be an issue with how static-i18n is configuring i18next.