### PR TITLE
CloudFlare doesn't Vary

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -6,41 +6,41 @@ RewriteEngine On
     # LANGUAGE REDIRECTS
     # ------------------
     RewriteCond %{HTTP:Accept-Language} ^de [NC]
-    RewriteRule ^$ /de/ [L,R=301]
+    RewriteRule ^$ /de/ [L,R=301,E=nocache:1]
 
     RewriteCond %{HTTP:Accept-Language} ^es-mx [NC]
-    RewriteRule ^$ /es-mx/ [L,R=301]
+    RewriteRule ^$ /es-mx/ [L,R=301,E=nocache:1]
 
     RewriteCond %{HTTP:Accept-Language} ^es [NC]
-    RewriteRule ^$ /es/ [L,R=301]
+    RewriteRule ^$ /es/ [L,R=301,E=nocache:1]
 
     RewriteCond %{HTTP:Accept-Language} ^fr [NC]
-    RewriteRule ^$ /fr/ [L,R=301]
+    RewriteRule ^$ /fr/ [L,R=301,E=nocache:1]
 
     RewriteCond %{HTTP:Accept-Language} ^it [NC]
-    RewriteRule ^$ /it/ [L,R=301]
+    RewriteRule ^$ /it/ [L,R=301,E=nocache:1]
 
     RewriteCond %{HTTP:Accept-Language} ^ja [NC]
-    RewriteRule ^$ /ja/ [L,R=301]
+    RewriteRule ^$ /ja/ [L,R=301,E=nocache:1]
 
     RewriteCond %{HTTP:Accept-Language} ^ko [NC]
-    RewriteRule ^$ /ko/ [L,R=301]
+    RewriteRule ^$ /ko/ [L,R=301,E=nocache:1]
 
     RewriteCond %{HTTP:Accept-Language} ^pl [NC]
-    RewriteRule ^$ /pl/ [L,R=301]
+    RewriteRule ^$ /pl/ [L,R=301,E=nocache:1]
 
     RewriteCond %{HTTP:Accept-Language} ^pt-br [NC]
-    RewriteRule ^$ /pt-br/ [L,R=301]
+    RewriteRule ^$ /pt-br/ [L,R=301,E=nocache:1]
 
     RewriteCond %{HTTP:Accept-Language} ^ru [NC]
-    RewriteRule ^$ /ru/ [L,R=301]
+    RewriteRule ^$ /ru/ [L,R=301,E=nocache:1]
 
     RewriteCond %{HTTP:Accept-Language} ^zh-cn [NC]
-    RewriteRule ^$ /zh-chs/ [L,R=301]
+    RewriteRule ^$ /zh-chs/ [L,R=301,E=nocache:1]
 
     RewriteCond %{HTTP:Accept-Language} ^zh-tw [NC]
-    RewriteRule ^$ /zh-cht/ [L,R=301]
+    RewriteRule ^$ /zh-cht/ [L,R=301,E=nocache:1]
 
     # Don't cache one language for another
-    Header always merge Vary "Accept-Language"
+    Header always set Cache-Control "no-cache" env=nocache
 </IfModule>


### PR DESCRIPTION
Apparently CloudFlare doesn't care for the Vary header. This is an alternative that uses an environment variable to set `Cache-Control: no-cache` on the 301 redirects.